### PR TITLE
Simple fix to use https wiki images.

### DIFF
--- a/factoriojs.ml
+++ b/factoriojs.ml
@@ -104,7 +104,7 @@ let rec gui_icon alt =
             done;
             src
     in
-    let src = "http://wiki.factorio.com/images/"^src^".png" in
+    let src = "https://wiki.factorio.com/images/"^src^".png" in
     let href =
       match Hashtbl.find special_hrefs alt with
         | href ->
@@ -120,7 +120,7 @@ let rec gui_icon alt =
             done;
             href
     in
-    let href = "http://wiki.factorio.com/index.php?title="^href in
+    let href = "https://wiki.factorio.com/index.php?title="^href in
     a ~href [ img ~class_: "icon" ~alt ~title: alt src ]
 
 let last_hash = ref ""


### PR DESCRIPTION
We receive big count of redirects and mixed content warning because of http images.