### PR TITLE
Fix #72: Compilation bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Alternatively, you can use OPAM (OCaml Package Manager, https://opam.ocaml.org):
     sudo apt-get install opam
     opam init
     opam switch 4.03.0
-    opam install js_of_ocaml
+    opam install js_of_ocaml js_of_ocaml-camlp4
 
 ### Windows:
 
@@ -44,7 +44,7 @@ Open the OCaml terminal that the installation produces and run the following:
 
     opam init
     opam switch 4.03.0
-    opam install js_of_ocaml
+    opam install js_of_ocaml js_of_ocaml-camlp4
 
 ## Compile Factorio Planner
 

--- a/_tags
+++ b/_tags
@@ -1,3 +1,3 @@
 true: debug
 true: package(js_of_ocaml)
-true: package(js_of_ocaml.syntax), syntax(camlp4o)
+true: package(js_of_ocaml-camlp4), syntax(camlp4o)

--- a/factoriojs.ml
+++ b/factoriojs.ml
@@ -114,7 +114,7 @@ let rec gui_icon alt =
               else if i > 0 then
                 Bytes.set src i (Char.lowercase_ascii chr)
             done;
-            src
+            Bytes.to_string src
     in
     let src = "https://wiki.factorio.com/images/"^src^".png" in
     let href =
@@ -130,7 +130,7 @@ let rec gui_icon alt =
               else if i > 0 then
                 Bytes.set href i (Char.lowercase_ascii chr)
             done;
-            href
+            Bytes.to_string href
     in
     let href = "https://wiki.factorio.com/index.php?title="^href in
     a ~href [ img ~class_: "icon" ~alt ~title: alt src ]


### PR DESCRIPTION
This fixes compilation bugs for me. Tested with 4.03.0 and 4.07.1

It does require installing the js_of_ocaml-camlp4 module. I've added this to the readme's OPAM sections, but not the ubuntu section.